### PR TITLE
Fix typo in source-repository

### DIFF
--- a/comprehensions-ghc.cabal
+++ b/comprehensions-ghc.cabal
@@ -71,4 +71,4 @@ test-suite test
 
 source-repository head
   type:     git
-  location: https://github.com/strake/comprehensions-ghc.hs
+  location: https://github.com/strake/comprehensions-ghc.git


### PR DESCRIPTION
I just noticed a minor typo.